### PR TITLE
Upgrade to the latest

### DIFF
--- a/jmeter-plugin/build.gradle
+++ b/jmeter-plugin/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     compile('org.apache.jmeter:ApacheJMeter_core:3.1')
     compile('org.apache.jmeter:ApacheJMeter_java:3.1')
     compile('org.springframework:spring-webflux:5.0.0.BUILD-SNAPSHOT')
-    compile('io.projectreactor:reactor-core:3.0.6.BUILD-SNAPSHOT')
+    compile('io.projectreactor:reactor-core:3.1.0.BUILD-SNAPSHOT')
     compile('io.projectreactor.ipc:reactor-netty:0.6.3.BUILD-SNAPSHOT')
     compile('io.projectreactor.ipc:reactor-ipc:0.6.2.BUILD-SNAPSHOT')
 }

--- a/spring5-ann/build.gradle
+++ b/spring5-ann/build.gradle
@@ -27,7 +27,6 @@ repositories {
 }
 
 dependencies {
-    compile "io.projectreactor:reactor-core:3.0.6.BUILD-SNAPSHOT"
 
     // With Tomcat
     

--- a/spring5-ann/src/main/java/com/example/HelloController.java
+++ b/spring5-ann/src/main/java/com/example/HelloController.java
@@ -2,7 +2,9 @@ package com.example;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,13 +40,16 @@ final class HelloController {
     }
 
     @GetMapping(value = "/json_interval", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
-    Flux<String> json_interval(@RequestParam(required = false, defaultValue = "100") long delayInterval) {
-        return Flux.interval(Duration.ofMillis(delayInterval)).map(l -> "foo " + l).onBackpressureDrop();
+    Flux<Map<String,Long>> json_interval(@RequestParam(required = false, defaultValue = "100") long delayInterval) {
+        return Flux.interval(Duration.ofMillis(delayInterval))
+                .map(l -> Collections.singletonMap("foo", l)).onBackpressureDrop();
     }
 
     @GetMapping(value = "/json_list", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
-    Flux<String> json_list(@RequestParam(required = false, defaultValue = "100") long delayInterval) {
-        return Flux.fromIterable(list).delayElements(Duration.ofMillis(delayInterval)).onBackpressureDrop();
+    Flux<Map<String,String>> json_list(@RequestParam(required = false, defaultValue = "100") long delayInterval) {
+        return Flux.fromIterable(list).delayElements(Duration.ofMillis(delayInterval))
+                .map(l -> Collections.singletonMap("foo ", l))
+                .onBackpressureDrop();
     }
 
 }

--- a/spring5-func/build.gradle
+++ b/spring5-func/build.gradle
@@ -28,7 +28,6 @@ repositories {
 
 
 dependencies {
-    compile "io.projectreactor:reactor-core:3.0.6.BUILD-SNAPSHOT"
 
     // With Tomcat
     

--- a/spring5-mvc/build.gradle
+++ b/spring5-mvc/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 
 dependencies {
-    compile('io.projectreactor:reactor-core:3.0.6.BUILD-SNAPSHOT')
+    compile('io.projectreactor:reactor-core:3.1.0.BUILD-SNAPSHOT')
 
     // With Tomcat
     compile('org.springframework.boot:spring-boot-starter-web')

--- a/spring5-mvc/src/main/java/com/example/HelloController.java
+++ b/spring5-mvc/src/main/java/com/example/HelloController.java
@@ -33,8 +33,8 @@ final class HelloController {
     }
 
     @GetMapping(value = "/delay", produces = MediaType.TEXT_PLAIN_VALUE)
-    Mono<ByteBuffer> delay(@RequestParam(required = false, defaultValue = "2000") long delayInterval) {
-        return Mono.just(buffer).delayElement(Duration.ofMillis(delayInterval));
+    Mono<byte[]> delay(@RequestParam(required = false, defaultValue = "2000") long delayInterval) {
+        return Mono.just(buffer.array()).delayElement(Duration.ofMillis(delayInterval));
     }
 
     @GetMapping(value = "/json_interval", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)


### PR DESCRIPTION
reactor-core snapshots: 3.0.6 -> 3.1.0

The `Flux<String>` -> `Flux<Map<String, Long>>` change relates to:
https://github.com/spring-projects/spring-framework/commit/3efb76c85285bd9899552dd2cb57ec3ae1920174